### PR TITLE
Add constant functions and exponent operator

### DIFF
--- a/Source/Expressive/Context.cs
+++ b/Source/Expressive/Context.cs
@@ -174,6 +174,9 @@ namespace Expressive
             this.RegisterFunction(new SumFunction());
             this.RegisterFunction(new TanFunction());
             this.RegisterFunction(new TruncateFunction());
+            // Mathematical Constants
+            this.RegisterFunction(new EFunction());
+            this.RegisterFunction(new PIFunction());
             // Logical
             this.RegisterFunction(new IfFunction());
             this.RegisterFunction(new InFunction());

--- a/Source/Expressive/Expressions/Binary/Multiplicative/ExponentExpression.cs
+++ b/Source/Expressive/Expressions/Binary/Multiplicative/ExponentExpression.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using Expressive.Helpers;
+
+namespace Expressive.Expressions.Binary.Multiplicative
+{
+    internal class ExponentExpression : BinaryExpressionBase
+    {
+        #region Constructors
+
+        public ExponentExpression(IExpression lhs, IExpression rhs, Context context) : base(lhs, rhs, context)
+        {
+        }
+
+        #endregion
+
+        #region BinaryExpressionBase Members
+
+        protected override object EvaluateImpl(object lhsResult, IExpression rightHandSide, IDictionary<string, object> variables) =>
+            EvaluateAggregates(lhsResult, rightHandSide, variables, (l, r) =>
+                Math.Pow(Convert.ToDouble(l), Convert.ToDouble(r)));
+
+        #endregion
+    }
+}

--- a/Source/Expressive/Functions/FunctionBase.cs
+++ b/Source/Expressive/Functions/FunctionBase.cs
@@ -31,7 +31,11 @@ namespace Expressive.Functions
         /// <returns>True if the correct number are present, false otherwise.</returns>
         protected bool ValidateParameterCount(IExpression[] parameters, int expectedCount, int minimumCount)
         {
-            if (expectedCount != -1 && (parameters is null || !parameters.Any() || parameters.Length != expectedCount))
+            if (expectedCount == 0 && (parameters.Any() || parameters.Length != expectedCount))
+            {
+                throw new ParameterCountMismatchException($"{this.Name}() does not take any arguments");
+            }
+            if (expectedCount != -1 && expectedCount != 0 && (parameters is null || !parameters.Any() || parameters.Length != expectedCount))
             {
                 throw new ParameterCountMismatchException($"{this.Name}() takes only {expectedCount} argument(s)");
             }

--- a/Source/Expressive/Functions/Mathematical/EFunction.cs
+++ b/Source/Expressive/Functions/Mathematical/EFunction.cs
@@ -1,0 +1,18 @@
+﻿using Expressive.Expressions;
+using Expressive.Helpers;
+using System;
+
+
+namespace Expressive.Functions.Mathematical
+{
+    internal class EFunction : FunctionBase
+    {
+        public override string Name { get { return "E"; } }
+
+        public override object Evaluate(IExpression[] parameters, Context context)
+        {
+            this.ValidateParameterCount(parameters, 0, 0);
+            return Math.E;
+        }
+    }
+}

--- a/Source/Expressive/Functions/Mathematical/PIFunction.cs
+++ b/Source/Expressive/Functions/Mathematical/PIFunction.cs
@@ -1,0 +1,18 @@
+﻿using Expressive.Expressions;
+using Expressive.Helpers;
+using System;
+
+
+namespace Expressive.Functions.Mathematical
+{
+    internal class PIFunction : FunctionBase
+    {
+        public override string Name { get { return "PI"; } }
+
+        public override object Evaluate(IExpression[] parameters, Context context)
+        {
+            this.ValidateParameterCount(parameters, 0, 0);
+            return Math.PI;
+        }
+    }
+}

--- a/Source/Expressive/Operators/Multiplicative/ExponentOperator.cs
+++ b/Source/Expressive/Operators/Multiplicative/ExponentOperator.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections.Generic;
+using Expressive.Expressions;
+using Expressive.Expressions.Binary.Multiplicative;
+
+namespace Expressive.Operators.Multiplicative
+{
+    internal class ExponentOperator : OperatorBase
+    {
+        #region OperatorBase Members
+
+        public override IEnumerable<string> Tags => new[] { "^", "\u2038" };
+
+        public override IExpression BuildExpression(Token previousToken, IExpression[] expressions, Context context)
+        {
+            return new ExponentExpression(expressions[0], expressions[1], context);
+        }
+
+        public override OperatorPrecedence GetPrecedence(Token previousToken)
+        {
+            return OperatorPrecedence.Multiply;
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
This PR includes:
- Code for `E()` and `PI()` functions that return the constants _e_ and _pi_ respectively, addressing #37;
- Code for a binary `ExponentOperator`, set up to use the `^` (caret) symbol as the operator.

The E() and PI() functions are registered in `Context`'s constructor.

Code was not added to register `ExponentOperator` in `Context`'s constructor. That code needs to be part of the approach selected to address [The caret ^ as Exponent rather than Bitwise XOR](https://github.com/bijington/expressive/discussions/86#discussioncomment-237948) in #86.