### PR TITLE
Reverted to only wrapping the variables if we internally expect a

### DIFF
--- a/Source/Expressive/Context.cs
+++ b/Source/Expressive/Context.cs
@@ -62,7 +62,7 @@ namespace Expressive
             ? StringComparison.OrdinalIgnoreCase
             : StringComparison.Ordinal;
 
-        private bool IsCaseInsensitiveParsingEnabled =>
+        internal bool IsCaseInsensitiveParsingEnabled =>
 #pragma warning disable 618 // As it is our own warning this is safe enough until we actually get rid
             Options.HasFlag(ExpressiveOptions.IgnoreCase) || Options.HasFlag(ExpressiveOptions.IgnoreCaseForParsing);
 #pragma warning restore 618

--- a/Source/Expressive/Expression.cs
+++ b/Source/Expressive/Expression.cs
@@ -100,7 +100,8 @@ namespace Expressive
             {
                 this.CompileExpression();
 
-                if (variables != null)
+                if (variables != null &&
+                    this.context.IsCaseInsensitiveParsingEnabled)
                 {
                     variables = new Dictionary<string, object>(variables, this.context.ParsingStringComparer);
                 }


### PR DESCRIPTION
different EqualityComparer.