### PR TITLE
Target .NET Standard 2.0 as well.

### DIFF
--- a/Source/Expressive/Expressive.csproj
+++ b/Source/Expressive/Expressive.csproj
@@ -17,7 +17,7 @@
     <PackageTags>Expression Parser Evaluator Cross-Platform NET Standard Xamarin Xamarin.Forms</PackageTags>
     <PackageIcon>logo-64.png</PackageIcon>
     <PackageIconUrl />
-    <PackageLicenseFile>license.txt</PackageLicenseFile>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IncludeSymbols>true</IncludeSymbols>
@@ -29,9 +29,6 @@
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DocumentationFile>C:\Work\expressive\Source\Expressive\Expressive.xml</DocumentationFile>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
   </PropertyGroup>
 
@@ -41,10 +38,6 @@
       <PackagePath></PackagePath>
     </None>
     <None Include="..\ExpressiveStrongName.snk" Link="ExpressiveStrongName.snk" />
-    <None Include="..\license.txt">
-      <Pack>True</Pack>
-      <PackagePath></PackagePath>
-    </None>
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/Expressive/Expressive.csproj
+++ b/Source/Expressive/Expressive.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.4;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard1.4;netstandard2.0;net45</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\ExpressiveStrongName.snk</AssemblyOriginatorKeyFile>
     <AssemblyVersion>0.0.0.0</AssemblyVersion>


### PR DESCRIPTION
[It is recommended](https://docs.microsoft.com/en-us/dotnet/standard/library-guidance/cross-platform-targeting) that projects targeting .NET Standard 1.x still target .NET Standard 2.0. Otherwise lots of unneeded dependencies are brought when using the library from modern frameworks (to see for yourself try creating a new project, install `Expressive` from NuGet, build it, and check the `.deps.json` file).