### PR TITLE
issue-126-null-value-smaller-than-any-numeric

### DIFF
--- a/Source/Expressive.Tests/ExpressionTests.cs
+++ b/Source/Expressive.Tests/ExpressionTests.cs
@@ -162,6 +162,10 @@ namespace Expressive.Tests
             Assert.AreEqual(true, new Expression("1 <= 2").Evaluate());
             Assert.AreEqual(false, new Expression("7 < 2").Evaluate());
             Assert.AreEqual(true, new Expression("1 < 2").Evaluate());
+            Assert.AreEqual(true, new Expression("[var1] < 1").Evaluate(new Dictionary<string, object> { ["var1"] = null}));
+            Assert.AreEqual(false, new Expression("[var1] > 1").Evaluate(new Dictionary<string, object> { ["var1"] = null}));
+            Assert.AreEqual(false, new Expression("[var1] < 1", ExpressiveOptions.Strict).Evaluate(new Dictionary<string, object> { ["var1"] = null}));
+            Assert.AreEqual(false, new Expression("[var1] > 1", ExpressiveOptions.Strict).Evaluate(new Dictionary<string, object> { ["var1"] = null}));
 
             // Dates can be parsed to string.
             Assert.AreEqual(true, new Expression("[date1] == '2016-01-01'").Evaluate(new Dictionary<string, object> { ["date1"] = new DateTime(2016, 01, 01) }));

--- a/Source/Expressive.Tests/Expressions/Binary/Relational/GreaterThanExpressionTests.cs
+++ b/Source/Expressive.Tests/Expressions/Binary/Relational/GreaterThanExpressionTests.cs
@@ -26,12 +26,29 @@ namespace Expressive.Tests.Expressions.Binary.Relational
         [TestCase(1.001, 1.001, false)]
         [TestCase(1, 1.00, false)]
         [TestCase(1.00, 1, false)]
+        [TestCase(null, 1, false)]
+        [TestCase(1, null, true)]
         public static void TestEvaluate(object lhs, object rhs, object expectedValue)
         {
             var expression = new GreaterThanExpression(
                 Mock.Of<IExpression>(e => e.Evaluate(It.IsAny<IDictionary<string, object>>()) == lhs),
                 Mock.Of<IExpression>(e => e.Evaluate(It.IsAny<IDictionary<string, object>>()) == rhs),
                 new Context(ExpressiveOptions.None));
+
+            Assert.That(expression.Evaluate(null), Is.EqualTo(expectedValue));
+        }
+
+        [TestCase(null, 1, false)]
+        [TestCase(1, null, false)]
+        [TestCase(null, null, false)]
+        [TestCase(null, "abc", false)]
+        [TestCase("abc", null, false)]
+        public static void TestEvaluateWithStrictMode(object lhs, object rhs, object expectedValue)
+        {
+            var expression = new GreaterThanExpression(
+                Mock.Of<IExpression>(e => e.Evaluate(It.IsAny<IDictionary<string, object>>()) == lhs),
+                Mock.Of<IExpression>(e => e.Evaluate(It.IsAny<IDictionary<string, object>>()) == rhs),
+                new Context(ExpressiveOptions.Strict));
 
             Assert.That(expression.Evaluate(null), Is.EqualTo(expectedValue));
         }

--- a/Source/Expressive.Tests/Expressions/Binary/Relational/GreaterThanOrEqualExpressionTests.cs
+++ b/Source/Expressive.Tests/Expressions/Binary/Relational/GreaterThanOrEqualExpressionTests.cs
@@ -26,12 +26,29 @@ namespace Expressive.Tests.Expressions.Binary.Relational
         [TestCase(1.001, 1.001, true)]
         [TestCase(1, 1.00, true)]
         [TestCase(1.00, 1, true)]
+        [TestCase(null, 1, false)]
+        [TestCase(1, null, true)]
         public static void TestEvaluate(object lhs, object rhs, object expectedValue)
         {
             var expression = new GreaterThanOrEqualExpression(
                 Mock.Of<IExpression>(e => e.Evaluate(It.IsAny<IDictionary<string, object>>()) == lhs),
                 Mock.Of<IExpression>(e => e.Evaluate(It.IsAny<IDictionary<string, object>>()) == rhs),
                 new Context(ExpressiveOptions.None));
+
+            Assert.That(expression.Evaluate(null), Is.EqualTo(expectedValue));
+        }
+
+        [TestCase(null, 1, false)]
+        [TestCase(1, null, false)]
+        [TestCase(null, null, true)]
+        [TestCase(null, "abc", false)]
+        [TestCase("abc", null, false)]
+        public static void TestEvaluateWithStrictMode(object lhs, object rhs, object expectedValue)
+        {
+            var expression = new GreaterThanOrEqualExpression(
+                Mock.Of<IExpression>(e => e.Evaluate(It.IsAny<IDictionary<string, object>>()) == lhs),
+                Mock.Of<IExpression>(e => e.Evaluate(It.IsAny<IDictionary<string, object>>()) == rhs),
+                new Context(ExpressiveOptions.Strict));
 
             Assert.That(expression.Evaluate(null), Is.EqualTo(expectedValue));
         }

--- a/Source/Expressive.Tests/Expressions/Binary/Relational/LessThanExpressionTests.cs
+++ b/Source/Expressive.Tests/Expressions/Binary/Relational/LessThanExpressionTests.cs
@@ -26,12 +26,29 @@ namespace Expressive.Tests.Expressions.Binary.Relational
         [TestCase(1.001, 1.001, false)]
         [TestCase(1, 1.00, false)]
         [TestCase(1.00, 1, false)]
+        [TestCase(null, 1, true)]
+        [TestCase(1, null, false)]
         public static void TestEvaluate(object lhs, object rhs, object expectedValue)
         {
             var expression = new LessThanExpression(
                 Mock.Of<IExpression>(e => e.Evaluate(It.IsAny<IDictionary<string, object>>()) == lhs),
                 Mock.Of<IExpression>(e => e.Evaluate(It.IsAny<IDictionary<string, object>>()) == rhs),
                 new Context(ExpressiveOptions.None));
+
+            Assert.That(expression.Evaluate(null), Is.EqualTo(expectedValue));
+        }
+
+        [TestCase(null, 1, false)]
+        [TestCase(1, null, false)]
+        [TestCase(null, null, false)]
+        [TestCase(null, "abc", false)]
+        [TestCase("abc", null, false)]
+        public static void TestEvaluateWithStrictMode(object lhs, object rhs, object expectedValue)
+        {
+            var expression = new LessThanExpression(
+                Mock.Of<IExpression>(e => e.Evaluate(It.IsAny<IDictionary<string, object>>()) == lhs),
+                Mock.Of<IExpression>(e => e.Evaluate(It.IsAny<IDictionary<string, object>>()) == rhs),
+                new Context(ExpressiveOptions.Strict));
 
             Assert.That(expression.Evaluate(null), Is.EqualTo(expectedValue));
         }

--- a/Source/Expressive.Tests/Expressions/Binary/Relational/LessThanOrEqualExpressionTests.cs
+++ b/Source/Expressive.Tests/Expressions/Binary/Relational/LessThanOrEqualExpressionTests.cs
@@ -26,6 +26,8 @@ namespace Expressive.Tests.Expressions.Binary.Relational
         [TestCase(1.001, 1.001, true)]
         [TestCase(1, 1.00, true)]
         [TestCase(1.00, 1, true)]
+        [TestCase(null, 1, true)]
+        [TestCase(1, null, false)]
         public static void TestEvaluate(object lhs, object rhs, object expectedValue)
         {
             var expression = new LessThanOrEqualExpression(
@@ -35,5 +37,21 @@ namespace Expressive.Tests.Expressions.Binary.Relational
 
             Assert.That(expression.Evaluate(null), Is.EqualTo(expectedValue));
         }
+
+        [TestCase(null, 1, false)]
+        [TestCase(1, null, false)]
+        [TestCase(null, null, true)]
+        [TestCase(null, "abc", false)]
+        [TestCase("abc", null, false)]
+        public static void TestEvaluateWithStrictMode(object lhs, object rhs, object expectedValue)
+        {
+            var expression = new LessThanOrEqualExpression(
+                Mock.Of<IExpression>(e => e.Evaluate(It.IsAny<IDictionary<string, object>>()) == lhs),
+                Mock.Of<IExpression>(e => e.Evaluate(It.IsAny<IDictionary<string, object>>()) == rhs),
+                new Context(ExpressiveOptions.Strict));
+
+            Assert.That(expression.Evaluate(null), Is.EqualTo(expectedValue));
+        }
+
     }
 }

--- a/Source/Expressive/Expressions/Binary/Relational/GreaterThanExpression.cs
+++ b/Source/Expressive/Expressions/Binary/Relational/GreaterThanExpression.cs
@@ -15,8 +15,28 @@ namespace Expressive.Expressions.Binary.Relational
 
         #region BinaryExpressionBase Members
 
-        protected override object EvaluateImpl(object lhsResult, IExpression rightHandSide, IDictionary<string, object> variables) => 
-            Comparison.CompareUsingMostPreciseType(lhsResult, rightHandSide.Evaluate(variables), this.Context) > 0;
+        protected override object EvaluateImpl(object lhsResult, IExpression rightHandSide, IDictionary<string, object> variables)
+        {
+            object rhsResult = null;
+
+            if (Context.Options.HasFlag(ExpressiveOptions.Strict))
+            {
+                if (lhsResult is null)
+                {
+                    return false;
+                }
+
+                rhsResult = rightHandSide.Evaluate(variables);
+
+                // If we got here then the lhsResult is not null.
+                if (rhsResult is null)
+                {
+                    return false;
+                }
+            }
+
+            return Comparison.CompareUsingMostPreciseType(lhsResult, rhsResult ?? rightHandSide.Evaluate(variables), this.Context) > 0;
+        }
 
         #endregion
     }

--- a/Source/Expressive/Expressions/Binary/Relational/GreaterThanOrEqualExpression.cs
+++ b/Source/Expressive/Expressions/Binary/Relational/GreaterThanOrEqualExpression.cs
@@ -15,8 +15,25 @@ namespace Expressive.Expressions.Binary.Relational
 
         #region BinaryExpressionBase Members
 
-        protected override object EvaluateImpl(object lhsResult, IExpression rightHandSide, IDictionary<string, object> variables) => 
-            Comparison.CompareUsingMostPreciseType(lhsResult, rightHandSide.Evaluate(variables), this.Context) >= 0;
+        protected override object EvaluateImpl(object lhsResult, IExpression rightHandSide, IDictionary<string, object> variables)
+        {
+            object rhsResult = rightHandSide.Evaluate(variables);
+
+            if (Context.Options.HasFlag(ExpressiveOptions.Strict))
+            {
+                if (lhsResult is null && rhsResult is null)
+                {
+                    return true;
+                }
+
+                if (lhsResult is null || rhsResult is null)
+                {
+                    return false;
+                }
+            }
+
+            return Comparison.CompareUsingMostPreciseType(lhsResult, rhsResult, this.Context) >= 0;
+        }
 
         #endregion
     }

--- a/Source/Expressive/Expressions/Binary/Relational/LessThanExpression.cs
+++ b/Source/Expressive/Expressions/Binary/Relational/LessThanExpression.cs
@@ -15,8 +15,28 @@ namespace Expressive.Expressions.Binary.Relational
 
         #region BinaryExpressionBase Members
 
-        protected override object EvaluateImpl(object lhsResult, IExpression rightHandSide, IDictionary<string, object> variables) => 
-            Comparison.CompareUsingMostPreciseType(lhsResult, rightHandSide.Evaluate(variables), this.Context) < 0;
+        protected override object EvaluateImpl(object lhsResult, IExpression rightHandSide, IDictionary<string, object> variables)
+        {
+            object rhsResult = null;
+
+            if (Context.Options.HasFlag(ExpressiveOptions.Strict))
+            {
+                if (lhsResult is null)
+                {
+                    return false;
+                }
+
+                rhsResult = rightHandSide.Evaluate(variables);
+
+                // If we got here then the lhsResult is not null.
+                if (rhsResult is null)
+                {
+                    return false;
+                }
+            }
+
+            return Comparison.CompareUsingMostPreciseType(lhsResult, rhsResult ?? rightHandSide.Evaluate(variables), this.Context) < 0;
+        }
 
         #endregion
     }

--- a/Source/Expressive/Expressions/Binary/Relational/LessThanOrEqualExpression.cs
+++ b/Source/Expressive/Expressions/Binary/Relational/LessThanOrEqualExpression.cs
@@ -15,8 +15,25 @@ namespace Expressive.Expressions.Binary.Relational
 
         #region BinaryExpressionBase Members
 
-        protected override object EvaluateImpl(object lhsResult, IExpression rightHandSide, IDictionary<string, object> variables) => 
-            Comparison.CompareUsingMostPreciseType(lhsResult, rightHandSide.Evaluate(variables), this.Context) <= 0;
+        protected override object EvaluateImpl(object lhsResult, IExpression rightHandSide, IDictionary<string, object> variables)
+        {
+            object rhsResult = rightHandSide.Evaluate(variables);
+
+            if (Context.Options.HasFlag(ExpressiveOptions.Strict))
+            {
+                if (lhsResult is null && rhsResult is null)
+                {
+                    return true;
+                }
+
+                if (lhsResult is null || rhsResult is null)
+                {
+                    return false;
+                }
+            }
+
+            return Comparison.CompareUsingMostPreciseType(lhsResult, rhsResult, this.Context) <= 0;
+        }
 
         #endregion
     }

--- a/Source/Expressive/ExpressiveOptions.cs
+++ b/Source/Expressive/ExpressiveOptions.cs
@@ -45,10 +45,17 @@ namespace Expressive
         IgnoreCaseAll = IgnoreCaseForParsing | IgnoreCaseForEquality,
 
         /// <summary>
+        /// Specifies we're using strict mode for comparison
+        /// `False` will be returned if value `null` is a side expression for most of cases
+        /// e.g.: null < 1 -> False; null > 1 -> False; null > "abc" -> False; null < "abc" -> False;
+        /// </summary>
+        Strict = 64,
+
+        /// <summary>
         /// All options are used.
         /// </summary>
 #pragma warning disable 618 // As it is our own warning this is safe enough until we actually get rid
-        All = IgnoreCase | NoCache | RoundAwayFromZero | IgnoreCaseAll
+        All = IgnoreCase | NoCache | RoundAwayFromZero | IgnoreCaseAll | Strict
 #pragma warning restore 618
     }
 }


### PR DESCRIPTION
add new option `Strict` for handling some cases, currently only covers take the value `null` as part of Binary Relational Expression.

I don't think return `true` for the expression ( null < 1 ) is make sense in some scenarios

The mainly thought is in `Strict` mode, we'll always get `False` when a side expression equals to `null`, we may could throw a specific exception instead of particular value